### PR TITLE
Refine search & summary & delete & update commands

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -536,7 +536,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 - **Mainstream OS** - Windows, Linux, Unix, MacOS
 - **Private contact detail** - A contact detail that is not meant to be shared with others
-- **Applicant** – A applicant who has applied for a job and is stored as a contact in the system.
+- **Applicant** – An applicant who has applied for a job and is stored as a contact in the system.
 - **Application Metadata** – Information related to an applicant’s job application, such as job position, status, and contact details.
 - **Contact** – A stored applicant or candidate with essential details such as name, email, phone, job position, and application status.
 - **Custom Status** – A user-defined application status when the `--custom` flag is used.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -16,6 +16,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.UpdateCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -59,17 +60,23 @@ public class LogicManager implements Logic {
 
         if (pendingCommand != null) {
             if (commandText.equalsIgnoreCase("yes")) {
-                // currently only deletion needs the confirmation
-                DeleteCommand deleteCommand = (DeleteCommand) pendingCommand;
-                deleteCommand.setForceDelete(true);
-
-                System.out.println("deleting command");
-                commandResult = deleteCommand.execute(model);
-                pendingCommand = null;
+                // delete and update commands need the confirmation
+                if (pendingCommand instanceof DeleteCommand deleteCommand) {
+                    deleteCommand.setForceDelete(true);
+                    commandResult = deleteCommand.execute(model);
+                } else {
+                    UpdateCommand updateCommand = (UpdateCommand) pendingCommand;
+                    updateCommand.setForceUpdate(true);
+                    commandResult = updateCommand.execute(model);
+                }
             } else {
-                pendingCommand = null;
-                return new CommandResult("Deletion cancelled.");
+                if (pendingCommand instanceof DeleteCommand) {
+                    return new CommandResult("Deletion cancelled.");
+                } else {
+                    return new CommandResult("Update cancelled.");
+                }
             }
+            pendingCommand = null;
         } else {
             Command command = addressBookParser.parseCommand(commandText);
             commandResult = command.execute(model);

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -60,7 +60,6 @@ public class LogicManager implements Logic {
 
         if (pendingCommand != null) {
             if (commandText.equalsIgnoreCase("yes")) {
-                // delete and update commands need the confirmation
                 if (pendingCommand instanceof DeleteCommand deleteCommand) {
                     deleteCommand.setForceDelete(true);
                     commandResult = deleteCommand.execute(model);
@@ -70,11 +69,10 @@ public class LogicManager implements Logic {
                     commandResult = updateCommand.execute(model);
                 }
             } else {
-                if (pendingCommand instanceof DeleteCommand) {
-                    return new CommandResult("Deletion cancelled.");
-                } else {
-                    return new CommandResult("Update cancelled.");
-                }
+                String cancelMessage = pendingCommand instanceof DeleteCommand
+                        ? "Deletion cancelled."
+                        : "Update cancelled.";
+                return new CommandResult(cancelMessage);
             }
             pendingCommand = null;
         } else {
@@ -91,6 +89,11 @@ public class LogicManager implements Logic {
         return commandResult;
     }
 
+    /**
+     * Saves the current address book data to storage.
+     *
+     * @throws CommandException If an error occurs during saving
+     */
     public void saveAddressBook() throws CommandException {
         try {
             storage.saveAddressBook(model.getAddressBook());

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -24,6 +24,7 @@ public class Messages {
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_INVALID_CRITERIA_FORMAT = "Invalid criteria for %1$s \n%2$s";
     public static final String MESSAGE_NO_RESULT = "No applicants found.";
+    public static final String MESSAGE_UNKNOWN_FLAG = "Unknown flag: %1$s";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -23,6 +23,7 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_INVALID_CRITERIA_FORMAT = "Invalid criteria for %1$s \n%2$s";
+    public static final String MESSAGE_NO_RESULT = "No applicants found.";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -16,7 +16,7 @@ import seedu.address.model.Model;
 import seedu.address.model.applicant.Applicant;
 
 /**
- * Adds a applicant to the address book.
+ * Adds an applicant to the address book.
  */
 public class AddCommand extends Command {
 
@@ -88,11 +88,10 @@ public class AddCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof AddCommand)) {
+        if (!(other instanceof AddCommand otherAddCommand)) {
             return false;
         }
 
-        AddCommand otherAddCommand = (AddCommand) other;
         return toAdd.equals(otherAddCommand.toAdd);
     }
     

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -22,7 +22,7 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a applicant to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an applicant to the address book. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -70,7 +70,8 @@ public class CommandResult {
      * Currently used specifically for deletion confirmation.
      */
     public boolean isConfirmation() {
-        return feedbackToUser.equals(DeleteCommand.MESSAGE_CONFIRMATION_REQUIRED);
+        System.out.println(feedbackToUser.matches("(?s)^Are you sure you want to.*"));
+        return feedbackToUser.matches("(?s)^Are you sure you want to.*");
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/ConfirmationRequiredCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ConfirmationRequiredCommand.java
@@ -1,0 +1,241 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.applicant.Applicant;
+import seedu.address.model.applicant.IdentifierPredicate;
+
+/**
+ * An abstract base class for commands that require user confirmation before execution.
+ * <p>
+ * Provides common functionality for commands that need to:
+ * <ul>
+ *   <li>Filter applicants using predicates or index</li>
+ *   <li>Handle confirmation prompts</li>
+ *   <li>Support force operation flags</li>
+ *   <li>Process applicants in bulk or individually</li>
+ * </ul>
+ *
+ * Concrete subclasses must implement the specific processing logic and messages.
+ */
+public abstract class ConfirmationRequiredCommand extends Command {
+
+    /** The predicates used to filter applicants, or null if using index */
+    protected final List<IdentifierPredicate> predicates;
+
+    /** The index of the target applicant, or null if using predicates */
+    protected final Index targetIndex;
+
+    /** Flag indicating whether to skip confirmation prompts */
+    protected boolean isForceOperation;
+
+    /**
+     * Constructs a ConfirmationRequiredCommand that operates on applicants matching the given predicates.
+     *
+     * @param predicates The list of predicates to filter applicants, must not be null
+     * @param isForceOperation Whether to skip confirmation prompts
+     * @throws NullPointerException if predicates is null
+     */
+    protected ConfirmationRequiredCommand(List<IdentifierPredicate> predicates, boolean isForceOperation) {
+        requireNonNull(predicates);
+        this.predicates = predicates;
+        this.targetIndex = null;
+        this.isForceOperation = isForceOperation;
+    }
+
+    /**
+     * Constructs a ConfirmationRequiredCommand that operates on the applicant at the given index.
+     *
+     * @param targetIndex The index of the applicant to process, must not be null
+     * @param isForceOperation Whether to skip confirmation prompts
+     * @throws NullPointerException if targetIndex is null
+     */
+    protected ConfirmationRequiredCommand(Index targetIndex, boolean isForceOperation) {
+        requireNonNull(targetIndex);
+        this.predicates = null;
+        this.targetIndex = targetIndex;
+        this.isForceOperation = isForceOperation;
+    }
+
+    /**
+     * Executes the command by delegating to either predicate-based or index-based execution.
+     *
+     * @param model The model to execute the command on, must not be null
+     * @return The command result containing either confirmation or success message
+     * @throws CommandException If an error occurs during execution
+     * @throws NullPointerException if model is null
+     */
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        assert (predicates != null && targetIndex == null) || (predicates == null && targetIndex != null)
+                : "Command must use either predicates or index, but not both";
+
+        return targetIndex == null ? executeWithPredicates(model) : executeWithIndex(model);
+    }
+
+    /**
+     * Executes the command using the stored predicates to filter applicants.
+     *
+     * @param model The model to execute on, must not be null
+     * @return The command result containing either confirmation or success message
+     * @throws CommandException If no applicants match the predicates
+     * @throws NullPointerException if model is null
+     */
+    protected CommandResult executeWithPredicates(Model model) throws CommandException {
+        requireNonNull(model);
+        assert predicates != null : "Predicates must not be null in predicate-based execution";
+
+        model.updateFilteredPersonList(applicant ->
+                predicates.stream().allMatch(predicate -> predicate.test(applicant)));
+
+        List<Applicant> filteredList = model.getFilteredPersonList();
+        if (filteredList.isEmpty()) {
+            throw new CommandException(getNoResultMessage());
+        }
+
+        if (!isForceOperation) {
+            return new CommandResult(getConfirmationMessage());
+        }
+
+        List<Applicant> applicantsToProcess = List.copyOf(filteredList);
+        processApplicants(model, applicantsToProcess);
+
+        String processedApplicants = applicantsToProcess.stream()
+                .map(Messages::format)
+                .collect(Collectors.joining("\n\n"));
+
+        return new CommandResult(String.format(getSuccessMessage(), processedApplicants));
+    }
+
+    /**
+     * Executes the command using the stored index to identify the applicant.
+     *
+     * @param model The model to execute on, must not be null
+     * @return The command result containing either confirmation or success message
+     * @throws CommandException If the index is invalid
+     * @throws NullPointerException if model is null
+     */
+    protected CommandResult executeWithIndex(Model model) throws CommandException {
+        requireNonNull(model);
+        assert targetIndex != null : "Target index must not be null in index-based execution";
+
+        List<Applicant> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Applicant applicantToProcess = lastShownList.get(targetIndex.getZeroBased());
+        if (!isForceOperation) {
+            return new CommandResult(String.format(getIndexConfirmationMessage(), targetIndex.getOneBased()));
+        }
+
+        processApplicant(model, applicantToProcess);
+        return new CommandResult(String.format(getSuccessMessage(), Messages.format(applicantToProcess)));
+    }
+
+    // Abstract methods to be implemented by subclasses
+
+    /**
+     * Gets the message to display when no applicants match the criteria.
+     *
+     * @return The no result message
+     */
+    protected abstract String getNoResultMessage();
+
+    /**
+     * Gets the confirmation message for predicate-based operations.
+     *
+     * @return The confirmation message
+     */
+    protected abstract String getConfirmationMessage();
+
+    /**
+     * Gets the confirmation message for index-based operations.
+     *
+     * @return The confirmation message with %d placeholder for index
+     */
+    protected abstract String getIndexConfirmationMessage();
+
+    /**
+     * Gets the success message to display after successful execution.
+     *
+     * @return The success message with %s placeholder for applicant details
+     */
+    protected abstract String getSuccessMessage();
+
+    /**
+     * Processes multiple applicants (predicate-based operations).
+     *
+     * @param model The model to process against, must not be null
+     * @param applicants The applicants to process, must not be null
+     * @throws CommandException If processing fails
+     * @throws NullPointerException if model or applicants is null
+     */
+    protected abstract void processApplicants(Model model, List<Applicant> applicants) throws CommandException;
+
+    /**
+     * Processes a single applicant (index-based operations).
+     *
+     * @param model The model to process against, must not be null
+     * @param applicant The applicant to process, must not be null
+     * @throws CommandException If processing fails
+     * @throws NullPointerException if model or applicant is null
+     */
+    protected abstract void processApplicant(Model model, Applicant applicant) throws CommandException;
+
+    /**
+     * Sets the force operation flag.
+     *
+     * @param isForceOperation Whether to skip confirmation prompts
+     */
+    public void setForceOperation(boolean isForceOperation) {
+        this.isForceOperation = isForceOperation;
+    }
+
+    /**
+     * Checks equality based on predicates, target index, and force operation flag.
+     *
+     * @param other The object to compare with
+     * @return true if equal, false otherwise
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof ConfirmationRequiredCommand)) {
+            return false;
+        }
+
+        ConfirmationRequiredCommand otherCommand = (ConfirmationRequiredCommand) other;
+        return Objects.equals(predicates, otherCommand.predicates)
+                && Objects.equals(targetIndex, otherCommand.targetIndex)
+                && isForceOperation == otherCommand.isForceOperation;
+    }
+
+    /**
+     * Returns a string representation including predicates, target index, and force operation status.
+     *
+     * @return The string representation
+     */
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicates", predicates)
+                .add("targetIndex", targetIndex)
+                .add("isForceOperation", isForceOperation)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -52,13 +52,13 @@ public class DeleteCommand extends ConfirmationRequiredCommand {
                     + "Type anything else to cancel the deletion";
 
     /** Confirmation message for index-based deletion */
-    private static final String MESSAGE_ID_DELETE_CONFIRMATION =
+    static final String MESSAGE_ID_DELETE_CONFIRMATION =
             "Are you sure you want to delete applicant %d in the list?\n"
                     + "Type 'yes' to continue\n"
                     + "Type anything else to cancel the deletion";
 
     /** Success message after deletion */
-    private static final String MESSAGE_DELETE_SUCCESS = "Deleted Applicant(s): %1$s";
+    static final String MESSAGE_DELETE_SUCCESS = "Deleted Applicant(s): %1$s";
 
     /**
      * Creates a DeleteCommand that deletes applicants matching the given predicates.

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_NO_RESULT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AFTER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BEFORE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -47,7 +48,6 @@ public class DeleteCommand extends Command {
             "Are you sure you want to delete the following applicant(s)?\n"
                     + "Type 'yes' to continue\n"
                     + "Type anything else to cancel the deletion";
-    static final String MESSAGE_NO_MATCHING_PERSON = "No matching applicant found.";
     static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Applicant(s): %1$s";
 
     private final List<IdentifierPredicate> predicates;
@@ -102,7 +102,7 @@ public class DeleteCommand extends Command {
 
         List<Applicant> filteredList = model.getFilteredPersonList();
         if (filteredList.isEmpty()) {
-            throw new CommandException(MESSAGE_NO_MATCHING_PERSON);
+            throw new CommandException(MESSAGE_NO_RESULT);
         }
 
         if (!isForceDelete) {

--- a/src/main/java/seedu/address/logic/commands/RateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RateCommand.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.Messages.MESSAGE_NO_RESULT;
+
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
@@ -22,7 +24,6 @@ public class RateCommand extends Command {
             + "Parameters: IDENTIFIER_TYPE/KEYWORD r/RATING\n"
             + "Example: " + COMMAND_WORD + " n/Alex Yeoh + r/4";
 
-    public static final String MESSAGE_NO_MATCHES = "No applicant matches provided keyword!";
     public static final String MESSAGE_MULTIPLE_MATCHES = "%1$d persons matched keyword. Please be more specific!";
 
     public static final String MESSAGE_ASSIGN_RATING_SUCCESS = "Assigned a rating of %1$s to: %2$s";
@@ -75,7 +76,7 @@ public class RateCommand extends Command {
         model.updateFilteredPersonList(predicate);
         int numberOfMatches = model.getFilteredPersonListSize();
         if (numberOfMatches == 0) {
-            return new CommandResult(String.format(MESSAGE_NO_MATCHES));
+            return new CommandResult(MESSAGE_NO_RESULT);
         } else if (numberOfMatches > 1) {
             return new CommandResult(String.format(MESSAGE_MULTIPLE_MATCHES, numberOfMatches));
         }
@@ -129,6 +130,7 @@ public class RateCommand extends Command {
         }
 
         if (targetIndex == null) {
+            assert predicate != null;
             return predicate.equals(otherRateCommand.predicate) && rating.equals(otherRateCommand.rating);
         } else {
             return targetIndex.equals(otherRateCommand.targetIndex) && rating.equals(otherRateCommand.rating);

--- a/src/main/java/seedu/address/logic/commands/SearchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SearchCommand.java
@@ -91,26 +91,21 @@ public class SearchCommand extends Command {
             return true;
         }
 
-        if (!(other instanceof SearchCommand)) {
+        if (!(other instanceof SearchCommand otherSearchCommand)) {
             return false;
         }
-
-        SearchCommand otherSearchCommand = (SearchCommand) other;
 
         List<IdentifierPredicate> otherPredicates = otherSearchCommand.predicates;
         if (predicates.size() != otherPredicates.size()) {
             return false;
         }
-    
         for (int i = 0; i < predicates.size(); i++) {
             IdentifierPredicate thisPredicate = predicates.get(i);
             IdentifierPredicate thatPredicate = otherPredicates.get(i);
-    
             if (!thisPredicate.equals(thatPredicate)) {
                 return false;
             }
         }
-    
         return true;
     }
 

--- a/src/main/java/seedu/address/logic/commands/SearchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SearchCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_NO_RESULT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_JOB_POSITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -25,11 +26,6 @@ public class SearchCommand extends Command {
      * Command word to trigger the search functionality in the application.
      */
     public static final String COMMAND_WORD = "search";
-
-    /**
-     * Message displayed when no applicants match the search criteria.
-     */
-    public static final String MESSAGE_NO_RESULT = "Error: No applicants found.";
 
     /**
      * Usage message displayed when the user provides an incorrect format for the search command.

--- a/src/main/java/seedu/address/logic/commands/SearchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SearchCommand.java
@@ -1,18 +1,22 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_JOB_POSITION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 
 import java.util.List;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.logic.parser.CliSyntax;
 import seedu.address.model.Model;
 import seedu.address.model.applicant.IdentifierPredicate;
 
 /**
- * Finds and lists all applicants in the address book that match the given criteria.
+ * Finds and lists all applicants in the applicant records that match the given criteria.
  * Keyword matching is case-insensitive, exact match needed
  */
 public class SearchCommand extends Command {
@@ -31,13 +35,14 @@ public class SearchCommand extends Command {
      * Usage message displayed when the user provides an incorrect format for the search command.
      */
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Searches for applicants based on specified criteria.\n"
-            + "Parameters: [" + CliSyntax.PREFIX_NAME + "NAME] "
-            + "[" + CliSyntax.PREFIX_EMAIL + "EMAIL] "
-            + "[" + CliSyntax.PREFIX_JOB_POSITION + "JOB_POSITION] "
-            + "[" + CliSyntax.PREFIX_STATUS + "STATUS]\n"
-            + "Example: " + COMMAND_WORD + " " + CliSyntax.PREFIX_NAME + "John "
-            + CliSyntax.PREFIX_EMAIL + "john@example.com";
+            + ": Searches for applicants who match at least one of the specified criteria (logical OR).\n"
+            + "Parameters: [" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_PHONE + "PHONE] "
+            + "[" + PREFIX_EMAIL + "EMAIL] "
+            + "[" + PREFIX_JOB_POSITION + "JOB_POSITION] "
+            + "[" + PREFIX_STATUS + "STATUS]\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "John "
+            + PREFIX_EMAIL + "alice@example.com";
 
     /**
      * The list of predicates used to filter the applicant list.
@@ -66,8 +71,9 @@ public class SearchCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        // Combine all predicates using logical AND (all conditions must be met)
-        model.updateFilteredPersonList(person -> predicates.stream().allMatch(p -> p.test(person)));
+        // Combine all predicates using logical OR (at least one condition needs to be met)
+        model.updateFilteredPersonList(person -> predicates.stream()
+                .anyMatch(p -> p.test(person)));
 
         int count = model.getFilteredPersonList().size();
         if (count == 0) {

--- a/src/main/java/seedu/address/logic/commands/SummaryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SummaryCommand.java
@@ -74,6 +74,9 @@ public class SummaryCommand extends Command {
                 applicants.filtered(person -> predicates.stream()
                         .allMatch(p -> p.test(person)));
 
+        model.updateFilteredPersonList(person -> predicates.stream()
+                .allMatch(p -> p.test(person)));
+
         if (filteredList.isEmpty()) {
             throw new CommandException(MESSAGE_NO_RESULT);
         }
@@ -106,7 +109,38 @@ public class SummaryCommand extends Command {
                 String.format(MESSAGE_SUCCESS, filteredList.size(), applicants.size(), statisticsString)));
     }
 
-    // yuqian todo: equals method here do I extract it out for commands that use a lot of predicates?
+    /**
+     * Checks if this {@code SummaryCommand} is equal to another object.
+     *
+     * @param other The object to compare.
+     * @return True if the other object is a {@code SummaryCommand} with the same predicates.
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof SummaryCommand otherSummaryCommand)) {
+            return false;
+        }
+
+        List<IdentifierPredicate> otherPredicates = otherSummaryCommand.predicates;
+        if (predicates.size() != otherPredicates.size()) {
+            return false;
+        }
+
+        for (int i = 0; i < predicates.size(); i++) {
+            IdentifierPredicate thisPredicate = predicates.get(i);
+            IdentifierPredicate thatPredicate = otherPredicates.get(i);
+
+            if (!thisPredicate.equals(thatPredicate)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     /**
      * Returns a string representation of this {@code SummaryCommand}.

--- a/src/main/java/seedu/address/logic/commands/SummaryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SummaryCommand.java
@@ -1,25 +1,36 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
-
-import javafx.collections.ObservableList;
-import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.applicant.Applicant;
-import seedu.address.model.applicant.IdentifierPredicate;
-import seedu.address.model.Model;
-import seedu.address.model.applicant.JobPosition;
-import seedu.address.model.applicant.Status;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_JOB_POSITION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import javafx.collections.ObservableList;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.applicant.Applicant;
+import seedu.address.model.applicant.IdentifierPredicate;
+import seedu.address.model.applicant.JobPosition;
+import seedu.address.model.applicant.Status;
+
+/**
+ * Summarizes all applicants in the applicant records that match the given criteria.
+ * Keyword matching is case-insensitive, exact match needed
+ */
 public class SummaryCommand extends Command {
     public static final String COMMAND_WORD = "summary";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Summarizes the applicants based on a given parameter "
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Summarizes applicants who match all of the specified criteria (logical AND).\n"
             + "Parameters: [" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_JOB_POSITION + "JOB_POSITION] "
             + "[" + PREFIX_STATUS + "STATUS]\n"
@@ -27,7 +38,12 @@ public class SummaryCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Summarized %1$d / %2$d Applicants \n%3$s";
 
+    /**
+     * The list of predicates used to filter the applicant list.
+     * Each predicate corresponds to a specific summary criterion (e.g., name, email).
+     */
     private final List<IdentifierPredicate> predicates;
+
     /**
      * Creates a SummaryCommand to summarise the applicants based on the given identifier
      *
@@ -35,7 +51,7 @@ public class SummaryCommand extends Command {
      */
     public SummaryCommand(List<IdentifierPredicate> predicates) {
         // Note: Predicate can be null i.e summarise all candidates
-        this.predicates  = predicates;
+        this.predicates = predicates;
     }
 
     /**
@@ -54,7 +70,8 @@ public class SummaryCommand extends Command {
 
         // Combine all predicates using logical AND (all conditions must be met)
         ObservableList<Applicant> filteredList =
-                applicants.filtered(person -> predicates.stream().allMatch(p -> p.test(person)));
+                applicants.filtered(person -> predicates.stream()
+                        .allMatch(p -> p.test(person)));
 
         // Count how many Applicants per JobPosition
         Map<JobPosition, Long> jobPositionCountMap = filteredList.stream()
@@ -84,4 +101,17 @@ public class SummaryCommand extends Command {
                 String.format(MESSAGE_SUCCESS, filteredList.size(), applicants.size(), statisticsString)));
     }
 
+    // yuqian todo: equals method here do I extract it out for commands that use a lot of predicates?
+
+    /**
+     * Returns a string representation of this {@code SummaryCommand}.
+     *
+     * @return A string representation containing the predicates used in the summary.
+     */
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", predicates)
+                .toString();
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/SummaryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SummaryCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_NO_RESULT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_JOB_POSITION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -72,6 +73,10 @@ public class SummaryCommand extends Command {
         ObservableList<Applicant> filteredList =
                 applicants.filtered(person -> predicates.stream()
                         .allMatch(p -> p.test(person)));
+
+        if (filteredList.isEmpty()) {
+            throw new CommandException(MESSAGE_NO_RESULT);
+        }
 
         // Count how many Applicants per JobPosition
         Map<JobPosition, Long> jobPositionCountMap = filteredList.stream()

--- a/src/main/java/seedu/address/logic/commands/UpdateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdateCommand.java
@@ -53,13 +53,13 @@ public class UpdateCommand extends ConfirmationRequiredCommand {
                     + "Type anything else to cancel the update";
 
     /** Confirmation message for index-based updates */
-    private static final String MESSAGE_ID_UPDATE_CONFIRMATION =
+    static final String MESSAGE_ID_UPDATE_CONFIRMATION =
             "Are you sure you want to update applicant %d in the list?\n"
                     + "Type 'yes' to continue\n"
                     + "Type anything else to cancel the update";
 
     /** Success message after update */
-    private static final String MESSAGE_UPDATE_STATUS_SUCCESS = "Updated status of: %1$s";
+    static final String MESSAGE_UPDATE_STATUS_SUCCESS = "Updated status of: %1$s";
 
     /** The new status to set for matching applicants */
     private final Status status;

--- a/src/main/java/seedu/address/logic/commands/UpdateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdateCommand.java
@@ -1,6 +1,18 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_NO_RESULT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_AFTER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_BEFORE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_JOB_POSITION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+
 import java.util.List;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
@@ -18,37 +30,58 @@ public class UpdateCommand extends Command {
     public static final String COMMAND_WORD = "update";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Sets the application status of the applicant "
-            + "identified by the specified contact identifier (name, email, or phone).\n"
-            + "Parameters: IDENTIFIER_TYPE/KEYWORD s/STATUS\n"
+            + "identified by the provided identifier(s).\n"
+            + "Parameters: (Must include Status, and specify EITHER an ID or any combination of other identifiers) "
+            + "[" + PREFIX_ID + "INDEX] "
+            + "[" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_PHONE + "PHONE] "
+            + "[" + PREFIX_EMAIL + "EMAIL] "
+            + "[" + PREFIX_STATUS + "STATUS] "
+            + "[" + PREFIX_JOB_POSITION + "JOB_POSITION] "
+            + "[" + PREFIX_BEFORE + "YYYY-MM-DD] "
+            + "[" + PREFIX_AFTER + "YYYY-MM-DD] "
+            + "[--force]\n"
             + "Example: " + COMMAND_WORD + " n/Alex Yeoh s/Interview Scheduled";
 
-    public static final String MESSAGE_NO_MATCHES = "No applicant matches provided keyword!";
-    public static final String MESSAGE_MULTIPLE_MATCHES = "%1$d persons matched keyword. Please be more specific!";
+    static final String MESSAGE_UPDATE_CONFIRMATION =
+            "Are you sure you want to update the following applicant(s)?\n"
+                    + "Type 'yes' to continue\n"
+                    + "Type anything else to cancel the update";
 
-    public static final String MESSAGE_UPDATE_STATUS_SUCCESS = "Updated status of: %1$s";
+    static final String MESSAGE_ID_UPDATE_CONFIRMATION =
+            "Are you sure you want to update applicant %d in the list?\n"
+                    + "Type 'yes' to continue\n"
+                    + "Type anything else to cancel the update";
 
-    private final IdentifierPredicate predicate;
+    private static final String MESSAGE_UPDATE_STATUS_SUCCESS = "Updated status of: %1$s";
+
+    private final List<IdentifierPredicate> predicates;
     private final Index targetIndex;
     private final Status status;
+    private boolean isForceUpdate;
 
     /**
-     * @param predicate     The predicate used to identify the {@code Applicant} to be updated.
-     * @param status        The {@code Status} to which the {@code Applicant}'s status should be set to.
+     * @param predicates The predicate used to identify the {@code Applicant} to be updated.
+     * @param status    The {@code Status} to which the {@code Applicant}'s status should be set to.
+     * @param isForceUpdate The flag to specify whether it is force deletion or not.
      */
-    public UpdateCommand(IdentifierPredicate predicate, Status status) {
-        this.predicate = predicate;
+    public UpdateCommand(List<IdentifierPredicate> predicates, Status status, boolean isForceUpdate) {
+        this.predicates = predicates;
         this.targetIndex = null;
         this.status = status;
+        this.isForceUpdate = isForceUpdate;
     }
 
     /**
-     * @param targetIndex   The index of the {@code Applicant} to be updated in the filtered list.
-     * @param status        The {@code Status} to which the {@code Applicant}'s status should be set to.
+     * @param targetIndex The index of the {@code Applicant} to be updated in the filtered list.
+     * @param status      The {@code Status} to which the {@code Applicant}'s status should be set to.
+     * @param isForceUpdate The flag to specify whether it is force deletion or not.
      */
-    public UpdateCommand(Index targetIndex, Status status) {
-        this.predicate = null;
+    public UpdateCommand(Index targetIndex, Status status, boolean isForceUpdate) {
+        this.predicates = null;
         this.targetIndex = targetIndex;
         this.status = status;
+        this.isForceUpdate = isForceUpdate;
     }
 
     /**
@@ -57,6 +90,8 @@ public class UpdateCommand extends Command {
      */
     @Override
     public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
         if (targetIndex == null) {
             return updateByPredicate(model);
         } else {
@@ -64,17 +99,32 @@ public class UpdateCommand extends Command {
         }
     }
 
-    public CommandResult updateByPredicate(Model model) {
-        model.updateFilteredPersonList(predicate);
-        int numberOfMatches = model.getFilteredPersonListSize();
-        if (numberOfMatches == 0) {
-            return new CommandResult(String.format(MESSAGE_NO_MATCHES));
-        } else if (numberOfMatches > 1) {
-            return new CommandResult(String.format(MESSAGE_MULTIPLE_MATCHES, numberOfMatches));
+    public CommandResult updateByPredicate(Model model) throws CommandException {
+        requireNonNull(model);
+
+        // Apply filtering predicates
+        model.updateFilteredPersonList(applicant -> {
+            assert predicates != null;
+            return predicates.stream().allMatch(predicate -> predicate.test(applicant));
+        });
+
+        List<Applicant> filteredList = model.getFilteredPersonList();
+        if (filteredList.isEmpty()) {
+            throw new CommandException(MESSAGE_NO_RESULT);
         }
-        Applicant target = model.getFilteredPersonList().get(0);
-        Applicant updatedApplicant = model.setStatus(target, status);
-        return new CommandResult(String.format(MESSAGE_UPDATE_STATUS_SUCCESS, Messages.format(updatedApplicant)));
+
+        if (!isForceUpdate) {
+            return new CommandResult(MESSAGE_UPDATE_CONFIRMATION);
+        }
+        List<Applicant> applicantsToUpdate = List.copyOf(filteredList);
+        for (Applicant applicant : applicantsToUpdate) {
+            model.setStatus(applicant, status);
+        }
+        String updatedApplicants = applicantsToUpdate.stream()
+                .map(Messages::format)
+                .collect(Collectors.joining("\n\n"));
+
+        return new CommandResult(String.format(MESSAGE_UPDATE_STATUS_SUCCESS, updatedApplicants));
     }
 
     public CommandResult updateByIndex(Model model) throws CommandException {
@@ -83,9 +133,11 @@ public class UpdateCommand extends Command {
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
-
-        Applicant target = lastShownList.get(targetIndex.getZeroBased());
-        Applicant updatedApplicant = model.setStatus(target, status);
+        Applicant applicantToUpdate = lastShownList.get(targetIndex.getZeroBased());
+        if (!isForceUpdate) {
+            return new CommandResult(String.format(MESSAGE_ID_UPDATE_CONFIRMATION, targetIndex.getOneBased()));
+        }
+        Applicant updatedApplicant = model.setStatus(applicantToUpdate, status);
         return new CommandResult(String.format(MESSAGE_UPDATE_STATUS_SUCCESS, Messages.format(updatedApplicant)));
     }
 
@@ -100,14 +152,15 @@ public class UpdateCommand extends Command {
             return false;
         }
 
-        return predicate.equals(otherUpdateCommand.predicate);
+        assert predicates != null;
+        return predicates.equals(otherUpdateCommand.predicates);
     }
 
     @Override
     public String toString() {
         if (targetIndex == null) {
             return new ToStringBuilder(this)
-                    .add("predicate", predicate)
+                    .add("predicate", predicates)
                     .add("status", status)
                     .toString();
         } else {
@@ -116,5 +169,9 @@ public class UpdateCommand extends Command {
                     .add("status", status)
                     .toString();
         }
+    }
+
+    public void setForceUpdate(boolean isForceDelete) {
+        this.isForceUpdate = isForceDelete;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -47,11 +47,17 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_JOB_POSITION,
                 PREFIX_STATUS, PREFIX_ADDRESS);
+        assert argMultimap.getValue(PREFIX_NAME).isPresent();
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        assert argMultimap.getValue(PREFIX_PHONE).isPresent();
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+        assert argMultimap.getValue(PREFIX_EMAIL).isPresent();
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+        assert argMultimap.getValue(PREFIX_JOB_POSITION).isPresent();
         JobPosition jobPosition = ParserUtil.parseJobPosition(argMultimap.getValue(PREFIX_JOB_POSITION).get());
+        assert argMultimap.getValue(PREFIX_STATUS).isPresent();
         Status status = ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get());
+        assert argMultimap.getValue(PREFIX_ADDRESS).isPresent();
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -2,45 +2,25 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_JOB_POSITION;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.ParserUtil.COMMON_PREFIXES;
 import static seedu.address.logic.parser.ParserUtil.COMMON_PREFIXES_WITH_ID;
+import static seedu.address.logic.parser.ParserUtil.checkFlag;
 import static seedu.address.logic.parser.ParserUtil.extractPredicates;
+import static seedu.address.logic.parser.ParserUtil.numOfPrefixesPresent;
 
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Stream;
 
+import javafx.util.Pair;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.applicant.EmailMatchesKeywordPredicate;
 import seedu.address.model.applicant.IdentifierPredicate;
-import seedu.address.model.applicant.JobPositionMatchesPredicate;
-import seedu.address.model.applicant.NameMatchesKeywordPredicate;
-import seedu.address.model.applicant.PhoneMatchesKeywordPredicate;
-import seedu.address.model.applicant.StatusMatchesPredicate;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
  */
 public class DeleteCommandParser implements Parser<DeleteCommand> {
-
-    /** Mapping of prefixes to their respective predicate constructors. */
-    private static final Map<Prefix, Function<String, IdentifierPredicate>> predicateMapping = Map.of(
-            PREFIX_NAME, NameMatchesKeywordPredicate::new,
-            PREFIX_PHONE, PhoneMatchesKeywordPredicate::new,
-            PREFIX_EMAIL, EmailMatchesKeywordPredicate::new,
-            PREFIX_JOB_POSITION, JobPositionMatchesPredicate::new,
-            PREFIX_STATUS, StatusMatchesPredicate::new
-    );
-
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
      * and returns a DeleteCommand object for execution.
@@ -50,43 +30,31 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
     public DeleteCommand parse(String args) throws ParseException {
         requireNonNull(args);
 
-        // Check for --force flag first
-        boolean isForceDelete = args.contains("--force");
-        args = args.replace("--force", ""); // Remove --force from args
-
-        // Other flags that start with "--" are invalid
-        if (args.trim().matches(".*\\s--\\w+.*")) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-        }
-
+        boolean isForceDelete;
+        Pair<String, Boolean> checkFlagResult = checkFlag(args);
+        args = checkFlagResult.getKey();
+        isForceDelete = checkFlagResult.getValue();
 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, COMMON_PREFIXES_WITH_ID);
 
         argMultimap.verifyNoDuplicatePrefixesFor(COMMON_PREFIXES_WITH_ID);
 
-        int numOfPrefixesPresentOtherThanId = numOfPrefixesPresent(argMultimap, COMMON_PREFIXES);
+        boolean hasId = argMultimap.getValue(PREFIX_ID).isPresent();
+        int numOfPrefixesPresentExceptId = numOfPrefixesPresent(argMultimap, COMMON_PREFIXES);
         // Allow ONLY id or any combination of other identifiers
-        if ((numOfPrefixesPresentOtherThanId > 0 && argMultimap.getValue(PREFIX_ID).isPresent())
-            || (numOfPrefixesPresentOtherThanId == 0 && argMultimap.getValue(PREFIX_ID).isEmpty())) {
+        if ((numOfPrefixesPresentExceptId > 0 && hasId)
+            || (numOfPrefixesPresentExceptId == 0 && !hasId)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
 
         // If Index is provided, perform delete solely on the index
         if (argMultimap.getValue(PREFIX_ID).isPresent()) {
             Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_ID).get());
-            return new DeleteCommand(null, index, isForceDelete); // Use index-based constructor
+            return new DeleteCommand(index, isForceDelete); // Use index-based constructor
         }
 
         List<IdentifierPredicate> predicates = extractPredicates(argMultimap);
-        assert predicates.size() == numOfPrefixesPresentOtherThanId;
-        return new DeleteCommand(predicates, null, isForceDelete);
-    }
-
-    /**
-     * Counts the number of prefixes that have values in the given {@code ArgumentMultimap}.
-     * i.e. number of prefixes provided in the argument.
-     */
-    private static int numOfPrefixesPresent(ArgumentMultimap argMultimap, Prefix... prefixes) {
-        return (int) Stream.of(prefixes).filter(prefix -> argMultimap.getValue(prefix).isPresent()).count();
+        assert predicates.size() == numOfPrefixesPresentExceptId;
+        return new DeleteCommand(predicates, isForceDelete);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,21 +1,40 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_JOB_POSITION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
-
-import java.util.*;
-import java.util.function.Function;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.applicant.*;
+import seedu.address.model.applicant.Address;
+import seedu.address.model.applicant.Email;
+import seedu.address.model.applicant.EmailMatchesKeywordPredicate;
+import seedu.address.model.applicant.IdentifierPredicate;
+import seedu.address.model.applicant.JobPosition;
+import seedu.address.model.applicant.JobPositionMatchesPredicate;
+import seedu.address.model.applicant.Name;
+import seedu.address.model.applicant.NameMatchesKeywordPredicate;
+import seedu.address.model.applicant.Phone;
+import seedu.address.model.applicant.PhoneMatchesKeywordPredicate;
+import seedu.address.model.applicant.Rating;
+import seedu.address.model.applicant.Status;
+import seedu.address.model.applicant.StatusMatchesPredicate;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -30,12 +49,15 @@ public class ParserUtil {
      * predicates in the final command.
      */
     public static final Prefix[] PREFIX_ORDER = {
-            PREFIX_NAME, PREFIX_EMAIL, PREFIX_JOB_POSITION, PREFIX_STATUS
+        PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_JOB_POSITION, PREFIX_STATUS
     };
 
-    /** Mapping of prefixes to their respective predicate constructors. */
+    /**
+     * Mapping of prefixes to their respective predicate constructors.
+     */
     public static final Map<Prefix, Function<String, IdentifierPredicate>> predicateMapping = Map.of(
             PREFIX_NAME, NameMatchesKeywordPredicate::new,
+            PREFIX_PHONE, PhoneMatchesKeywordPredicate::new,
             PREFIX_EMAIL, EmailMatchesKeywordPredicate::new,
             PREFIX_JOB_POSITION, JobPositionMatchesPredicate::new,
             PREFIX_STATUS, StatusMatchesPredicate::new
@@ -60,6 +82,7 @@ public class ParserUtil {
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
+     *
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -28,7 +28,6 @@ import java.util.stream.Stream;
 import javafx.util.Pair;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
-import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.applicant.Address;
 import seedu.address.model.applicant.AfterDatePredicate;
@@ -94,6 +93,13 @@ public class ParserUtil {
         return predicates;
     }
 
+    /**
+     * Extracts date-related predicates from the argument multimap.
+     *
+     * @param argMultimap The parsed argument multimap.
+     * @param predicates  The list of predicates to which extracted predicates will be added.
+     * @throws ParseException if date parsing fails.
+     */
     static void extractPredicateFromDates(ArgumentMultimap argMultimap, List<IdentifierPredicate> predicates)
             throws ParseException {
         IdentifierPredicate predicate;
@@ -111,19 +117,26 @@ public class ParserUtil {
         }
     }
 
+    /**
+     * Checks for the presence of a flag in the argument string.
+     *
+     * @param args The input argument string.
+     * @return A pair containing the cleaned argument string and a boolean indicating
+     *      whether the --force flag was present.
+     * @throws ParseException if an unknown flag is encountered.
+     */
     public static Pair<String, Boolean> checkFlag(String args) throws ParseException {
+        // Check for --force flag
+        boolean isForceOperation = args.contains("--force");
+        System.out.println("isForceOperation: " + isForceOperation);
+        args = args.replace("--force", ""); // Remove --force from args
+
         // Flags other than --force that start with "--" are invalid
         if (args.matches(".*\\s--\\w+.*")) {
             System.out.println("checkFlag: " + args);
             String unknownFlag = args.trim().replaceAll(".*(--\\w+).*", "$1");
             throw new ParseException(String.format(MESSAGE_UNKNOWN_FLAG, unknownFlag));
         }
-
-        // Check for --force flag
-        boolean isForceOperation = args.contains("--force");
-        System.out.println("isForceOperation: " + isForceOperation);
-        args = args.replace("--force", ""); // Remove --force from args
-
 
         return new Pair<>(args, isForceOperation);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_FLAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_AFTER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BEFORE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -24,8 +25,10 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import javafx.util.Pair;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.applicant.Address;
 import seedu.address.model.applicant.AfterDatePredicate;
@@ -106,6 +109,31 @@ public class ParserUtil {
             predicate = new AfterDatePredicate(validAfterDate);
             predicates.add(predicate);
         }
+    }
+
+    public static Pair<String, Boolean> checkFlag(String args) throws ParseException {
+        // Flags other than --force that start with "--" are invalid
+        if (args.matches(".*\\s--\\w+.*")) {
+            System.out.println("checkFlag: " + args);
+            String unknownFlag = args.trim().replaceAll(".*(--\\w+).*", "$1");
+            throw new ParseException(String.format(MESSAGE_UNKNOWN_FLAG, unknownFlag));
+        }
+
+        // Check for --force flag
+        boolean isForceOperation = args.contains("--force");
+        System.out.println("isForceOperation: " + isForceOperation);
+        args = args.replace("--force", ""); // Remove --force from args
+
+
+        return new Pair<>(args, isForceOperation);
+    }
+
+    /**
+     * Counts the number of prefixes that have values in the given {@code ArgumentMultimap}.
+     * i.e. number of prefixes provided in the argument.
+     */
+    public static int numOfPrefixesPresent(ArgumentMultimap argMultimap, Prefix... prefixes) {
+        return (int) Stream.of(prefixes).filter(prefix -> argMultimap.getValue(prefix).isPresent()).count();
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/SearchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchCommandParser.java
@@ -37,7 +37,6 @@ public class SearchCommandParser implements Parser<SearchCommand> {
         if (predicates.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
         }
-        assert !predicates.isEmpty();
 
         return new SearchCommand(predicates);
     }

--- a/src/main/java/seedu/address/logic/parser/SearchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchCommandParser.java
@@ -2,7 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.ParserUtil.PREFIX_ORDER;
+import static seedu.address.logic.parser.ParserUtil.COMMON_PREFIXES;
 import static seedu.address.logic.parser.ParserUtil.extractPredicates;
 
 import java.util.List;
@@ -26,13 +26,14 @@ public class SearchCommandParser implements Parser<SearchCommand> {
     public SearchCommand parse(String args) throws ParseException {
         requireNonNull(args);
 
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ORDER);
-        if (!argMultimap.areAnyPrefixesPresent(PREFIX_ORDER)) {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, COMMON_PREFIXES);
+        if (!argMultimap.areAnyPrefixesPresent(COMMON_PREFIXES)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
         }
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ORDER);
+        argMultimap.verifyNoDuplicatePrefixesFor(COMMON_PREFIXES);
 
         List<IdentifierPredicate> predicates = extractPredicates(argMultimap);
+
         if (predicates.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/SearchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchCommandParser.java
@@ -30,7 +30,6 @@ public class SearchCommandParser implements Parser<SearchCommand> {
         if (!argMultimap.areAnyPrefixesPresent(PREFIX_ORDER)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
         }
-        //yuqian todo: check what is this verifyNoDuplicatePrefixesFor output
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ORDER);
 
         List<IdentifierPredicate> predicates = extractPredicates(argMultimap);

--- a/src/main/java/seedu/address/logic/parser/SearchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SearchCommandParser.java
@@ -2,9 +2,9 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.ParserUtil.*;
+import static seedu.address.logic.parser.ParserUtil.PREFIX_ORDER;
+import static seedu.address.logic.parser.ParserUtil.extractPredicates;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import seedu.address.logic.commands.SearchCommand;
@@ -20,45 +20,25 @@ public class SearchCommandParser implements Parser<SearchCommand> {
      * {@code SearchCommand} and returns a {@code SearchCommand} object for
      * execution.
      *
-     * @throws ParseException if the user input does not conform to the expected
-     * format.
+     * @throws ParseException if the user input does not conform to the expected format.
      */
     @Override
     public SearchCommand parse(String args) throws ParseException {
         requireNonNull(args);
 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ORDER);
-        System.out.println(argMultimap);
         if (!argMultimap.areAnyPrefixesPresent(PREFIX_ORDER)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
         }
+        //yuqian todo: check what is this verifyNoDuplicatePrefixesFor output
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ORDER);
 
         List<IdentifierPredicate> predicates = extractPredicates(argMultimap);
-
         if (predicates.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
         }
+        assert !predicates.isEmpty();
 
         return new SearchCommand(predicates);
     }
-
-    /**
-     * Extracts predicates from the given {@code ArgumentMultimap}.
-     *
-     * @param argMultimap The parsed argument multimap.
-     * @return A list of identifier predicates for filtering applicants.
-     */
-    private List<IdentifierPredicate> extractPredicates(ArgumentMultimap argMultimap) {
-        List<IdentifierPredicate> predicates = new ArrayList<>();
-
-        for (Prefix prefix : PREFIX_ORDER) {
-            if (argMultimap.getValue(prefix).isPresent()) {
-                String value = argMultimap.getValue(prefix).get();
-                predicates.add(predicateMapping.get(prefix).apply(value));
-            }
-        }
-
-        return predicates;
-    }
-
 }

--- a/src/main/java/seedu/address/logic/parser/SummaryCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SummaryCommandParser.java
@@ -1,31 +1,38 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.ParserUtil.PREFIX_ORDER;
+import static seedu.address.logic.parser.ParserUtil.extractPredicates;
+
+import java.util.List;
+
 import seedu.address.logic.commands.SearchCommand;
 import seedu.address.logic.commands.SummaryCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.applicant.IdentifierPredicate;
 
-import java.util.List;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.ParserUtil.extractPredicates;
-import static seedu.address.logic.parser.ParserUtil.predicateMapping;
-
+/**
+ * Parses input arguments and creates a new {@code SummaryCommand} object.
+ */
 public class SummaryCommandParser implements Parser<SummaryCommand> {
     /**
-     * Parses the given {@code String} of arguments in the context of the {@code SearchCommand}
-     * and returns a {@code SearchCommand} object for execution.
+     * Parses the given {@code String} of arguments in the context of the {@code SummaryCommand}
+     * and returns a {@code SummaryCommand} object for execution.
      *
      * @throws ParseException if the user input does not conform to the expected format.
      */
-
     @Override
     public SummaryCommand parse(String args) throws ParseException {
         // Note: There can be no predicates i.e. Summarize all
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
-                args, predicateMapping.keySet().toArray(new Prefix[0]));
+                args, PREFIX_ORDER);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ORDER);
+
         List<IdentifierPredicate> predicates = extractPredicates(argMultimap);
+        //yuqian todo: test this okay!
+        if (argMultimap.areAnyPrefixesPresent(PREFIX_ORDER) && predicates.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
+        }
         return new SummaryCommand(predicates);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SummaryCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SummaryCommandParser.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.ParserUtil.PREFIX_ORDER;
+import static seedu.address.logic.parser.ParserUtil.COMMON_PREFIXES;
 import static seedu.address.logic.parser.ParserUtil.extractPredicates;
 
 import java.util.List;
@@ -24,14 +24,13 @@ public class SummaryCommandParser implements Parser<SummaryCommand> {
     public SummaryCommand parse(String args) throws ParseException {
         // Note: There can be no predicates i.e. Summarize all
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
-                args, PREFIX_ORDER);
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ORDER);
+                args, COMMON_PREFIXES);
+        argMultimap.verifyNoDuplicatePrefixesFor(COMMON_PREFIXES);
 
         List<IdentifierPredicate> predicates = extractPredicates(argMultimap);
-        if (predicates.isEmpty() && !args.trim().equals("summary")) {
+        if (predicates.isEmpty() && !args.trim().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SummaryCommand.MESSAGE_USAGE));
         }
-
         return new SummaryCommand(predicates);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SummaryCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SummaryCommandParser.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.ParserUtil.extractPredicates;
 
 import java.util.List;
 
-import seedu.address.logic.commands.SearchCommand;
 import seedu.address.logic.commands.SummaryCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.applicant.IdentifierPredicate;
@@ -29,10 +28,10 @@ public class SummaryCommandParser implements Parser<SummaryCommand> {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ORDER);
 
         List<IdentifierPredicate> predicates = extractPredicates(argMultimap);
-        //yuqian todo: test this okay!
-        if (argMultimap.areAnyPrefixesPresent(PREFIX_ORDER) && predicates.isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
+        if (predicates.isEmpty() && !args.trim().equals("summary")) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SummaryCommand.MESSAGE_USAGE));
         }
+
         return new SummaryCommand(predicates);
     }
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -61,7 +61,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     //// applicant-level operations
 
     /**
-     * Returns true if a applicant with the same identity as {@code applicant} exists in the address book.
+     * Returns true if an applicant with the same identity as {@code applicant} exists in the address book.
      */
     public boolean hasPerson(Applicant applicant) {
         requireNonNull(applicant);
@@ -69,7 +69,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
-     * Adds a applicant to the address book.
+     * Adds an applicant to the address book.
      * The applicant must not already exist in the address book.
      */
     public void addPerson(Applicant p) {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -56,7 +56,7 @@ public interface Model {
     ReadOnlyAddressBook getAddressBook();
 
     /**
-     * Returns true if a applicant with the same identity as {@code applicant} exists in the address book.
+     * Returns true if an applicant with the same identity as {@code applicant} exists in the address book.
      */
     boolean hasPerson(Applicant applicant);
 

--- a/src/main/java/seedu/address/model/applicant/Address.java
+++ b/src/main/java/seedu/address/model/applicant/Address.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Applicant's address in the address book.
+ * Represents an applicant's address in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidAddress(String)}
  */
 public class Address {

--- a/src/main/java/seedu/address/model/applicant/Email.java
+++ b/src/main/java/seedu/address/model/applicant/Email.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Applicant's email in the address book.
+ * Represents an applicant's email in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidEmail(String)}
  */
 public class Email {

--- a/src/main/java/seedu/address/model/applicant/EmailMatchesKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/applicant/EmailMatchesKeywordPredicate.java
@@ -44,11 +44,10 @@ public class EmailMatchesKeywordPredicate extends IdentifierPredicate {
             return true;
         }
 
-        if (!(other instanceof EmailMatchesKeywordPredicate)) {
+        if (!(other instanceof EmailMatchesKeywordPredicate otherEmailMatchesKeywordPredicate)) {
             return false;
         }
 
-        EmailMatchesKeywordPredicate otherEmailMatchesKeywordPredicate = (EmailMatchesKeywordPredicate) other;
         return keyword.equals(otherEmailMatchesKeywordPredicate.keyword);
     }
 

--- a/src/main/java/seedu/address/model/applicant/JobPosition.java
+++ b/src/main/java/seedu/address/model/applicant/JobPosition.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Applicant's applying JobPosition.
+ * Represents an applicant's applying JobPosition.
  * Guarantees: immutable; is valid as declared in {@link #isValidJobPosition(String)}
  */
 public class JobPosition {

--- a/src/main/java/seedu/address/model/applicant/Name.java
+++ b/src/main/java/seedu/address/model/applicant/Name.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Applicant's name in the address book.
+ * Represents an applicant's name in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
 public class Name {

--- a/src/main/java/seedu/address/model/applicant/Phone.java
+++ b/src/main/java/seedu/address/model/applicant/Phone.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Applicant's phone number in the address book.
+ * Represents an applicant's phone number in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidPhone(String)}
  */
 public class Phone {

--- a/src/main/java/seedu/address/model/applicant/UniqueApplicantList.java
+++ b/src/main/java/seedu/address/model/applicant/UniqueApplicantList.java
@@ -47,7 +47,7 @@ public class UniqueApplicantList implements Iterable<Applicant> {
     }
 
     /**
-     * Adds a applicant to the list.
+     * Adds an applicant to the list.
      * The applicant must not already exist in the list.
      */
     public void add(Applicant toAdd) {

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -20,13 +20,18 @@ import seedu.address.model.UserPrefs;
 import seedu.address.model.applicant.Applicant;
 
 /**
- * Contains integration tests (interaction with the Model) and unit tests for
- * {@code DeleteCommand}.
+ * Contains integration tests (interaction with the Model) and unit tests for {@code DeleteCommand}.
  */
 public class DeleteCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
+    // ===== Index-based Deletion Tests =====
+
+    /**
+     * EP: Valid index within bounds, force delete
+     * BV: First index in unfiltered list
+     */
     @Test
     public void execute_validIndexUnfilteredList_forceDeleteSuccess() {
         Applicant applicantToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
@@ -41,6 +46,25 @@ public class DeleteCommandTest {
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
 
+    /**
+     * EP: Valid index within bounds, needs confirmation
+     * BV: Last index in unfiltered list
+     */
+    @Test
+    public void execute_validIndexUnfilteredList_needsConfirmation() {
+        Index lastIndex = Index.fromOneBased(model.getFilteredPersonList().size());
+        DeleteCommand deleteCommand = new DeleteCommand(lastIndex, false);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_ID_DELETE_CONFIRMATION,
+                lastIndex.getOneBased());
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, null);
+    }
+
+    /**
+     * EP: Invalid index (out of bounds)
+     * BV: size + 1
+     */
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
@@ -49,6 +73,9 @@ public class DeleteCommandTest {
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
+    /**
+     * EP: Valid index in filtered list, force delete
+     */
     @Test
     public void execute_validIndexFilteredList_forceDeleteSuccess() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
@@ -65,6 +92,12 @@ public class DeleteCommandTest {
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
+
+    // ===== Predicate-based Deletion Tests =====
+
+    // Note: Add tests for predicate-based deletion once implemented
+
+    // ===== Unit Tests =====
 
     @Test
     public void equals() {
@@ -97,8 +130,7 @@ public class DeleteCommandTest {
         Index targetIndex = Index.fromOneBased(1);
         DeleteCommand deleteCommand = new DeleteCommand(targetIndex, false);
         String expected = DeleteCommand.class.getCanonicalName()
-                + "{predicate=null, "
-                + "targetIndex=" + targetIndex + ", isForceDelete=false}";
+                + "{targetIndex=" + targetIndex + ", isForceDelete=false}";
         assertEquals(expected, deleteCommand.toString());
     }
 
@@ -107,7 +139,6 @@ public class DeleteCommandTest {
      */
     private void showNoPerson(Model model) {
         model.updateFilteredPersonList(p -> false);
-
         assertTrue(model.getFilteredPersonList().isEmpty());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -30,9 +30,9 @@ public class DeleteCommandTest {
     @Test
     public void execute_validIndexUnfilteredList_forceDeleteSuccess() {
         Applicant applicantToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(null, INDEX_FIRST_PERSON, true);
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON, true);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_SUCCESS,
                 Messages.format(applicantToDelete));
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
@@ -44,7 +44,7 @@ public class DeleteCommandTest {
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(null, outOfBoundIndex, false);
+        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex, false);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
@@ -54,9 +54,9 @@ public class DeleteCommandTest {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Applicant applicantToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(null, INDEX_FIRST_PERSON, true);
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON, true);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_SUCCESS,
                 Messages.format(applicantToDelete));
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
@@ -68,14 +68,14 @@ public class DeleteCommandTest {
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(null, INDEX_FIRST_PERSON, false);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(null, INDEX_SECOND_PERSON, false);
+        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON, false);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON, false);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(null, INDEX_FIRST_PERSON, false);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON, false);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false
@@ -88,14 +88,14 @@ public class DeleteCommandTest {
         assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
 
         // different force flag -> returns false
-        DeleteCommand deleteFirstCommandForce = new DeleteCommand(null, INDEX_FIRST_PERSON, true);
+        DeleteCommand deleteFirstCommandForce = new DeleteCommand(INDEX_FIRST_PERSON, true);
         assertFalse(deleteFirstCommand.equals(deleteFirstCommandForce));
     }
 
     @Test
     public void toStringMethod() {
         Index targetIndex = Index.fromOneBased(1);
-        DeleteCommand deleteCommand = new DeleteCommand(null, targetIndex, false);
+        DeleteCommand deleteCommand = new DeleteCommand(targetIndex, false);
         String expected = DeleteCommand.class.getCanonicalName()
                 + "{predicate=null, "
                 + "targetIndex=" + targetIndex + ", isForceDelete=false}";

--- a/src/test/java/seedu/address/logic/commands/UpdateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UpdateCommandTest.java
@@ -1,4 +1,154 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.applicant.Applicant;
+import seedu.address.model.applicant.Status;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for {@code UpdateCommand}.
+ */
 public class UpdateCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final Status newStatus = new Status("Interview Scheduled");
+
+    // ===== Index-based Update Tests =====
+
+    /**
+     * EP: Valid index within bounds, force update
+     * BV: First index in unfiltered list
+     */
+    @Test
+    public void execute_validIndexUnfilteredList_forceUpdateSuccess() {
+        Applicant applicantToUpdate = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        UpdateCommand updateCommand = new UpdateCommand(INDEX_FIRST_PERSON, newStatus, true);
+
+        String expectedMessage = String.format(UpdateCommand.MESSAGE_UPDATE_STATUS_SUCCESS,
+                Messages.format(applicantToUpdate));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setStatus(applicantToUpdate, newStatus);
+
+        assertCommandSuccess(updateCommand, model, expectedMessage, expectedModel);
+    }
+
+    /**
+     * EP: Valid index within bounds, needs confirmation
+     * BV: Last index in unfiltered list
+     */
+    @Test
+    public void execute_validIndexUnfilteredList_needsConfirmation() {
+        Index lastIndex = Index.fromOneBased(model.getFilteredPersonList().size());
+        UpdateCommand updateCommand = new UpdateCommand(lastIndex, newStatus, false);
+
+        String expectedMessage = String.format(UpdateCommand.MESSAGE_ID_UPDATE_CONFIRMATION,
+                lastIndex.getOneBased());
+
+        assertCommandSuccess(updateCommand, model, expectedMessage, null);
+    }
+
+    /**
+     * EP: Invalid index (out of bounds)
+     * BV: size + 1
+     */
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        UpdateCommand updateCommand = new UpdateCommand(outOfBoundIndex, newStatus, false);
+
+        assertCommandFailure(updateCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    /**
+     * EP: Valid index in filtered list, force update
+     */
+    @Test
+    public void execute_validIndexFilteredList_forceUpdateSuccess() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Applicant applicantToUpdate = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        UpdateCommand updateCommand = new UpdateCommand(INDEX_FIRST_PERSON, newStatus, true);
+
+        String expectedMessage = String.format(UpdateCommand.MESSAGE_UPDATE_STATUS_SUCCESS,
+                Messages.format(applicantToUpdate));
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setStatus(applicantToUpdate, newStatus);
+        showNoPerson(expectedModel);
+
+        assertCommandSuccess(updateCommand, model, expectedMessage, expectedModel);
+    }
+
+    // ===== Predicate-based Update Tests =====
+
+    // Note: Add tests for predicate-based updates once implemented
+
+    // ===== Unit Tests =====
+
+    @Test
+    public void equals() {
+        UpdateCommand updateFirstCommand = new UpdateCommand(INDEX_FIRST_PERSON, newStatus, false);
+        UpdateCommand updateSecondCommand = new UpdateCommand(INDEX_SECOND_PERSON, newStatus, false);
+
+        // same object -> returns true
+        assertTrue(updateFirstCommand.equals(updateFirstCommand));
+
+        // same values -> returns true
+        UpdateCommand updateFirstCommandCopy = new UpdateCommand(INDEX_FIRST_PERSON, newStatus, false);
+        assertTrue(updateFirstCommand.equals(updateFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(updateFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(updateFirstCommand.equals(null));
+
+        // different applicant -> returns false
+        assertFalse(updateFirstCommand.equals(updateSecondCommand));
+
+        // different force flag -> returns false
+        UpdateCommand updateFirstCommandForce = new UpdateCommand(INDEX_FIRST_PERSON, newStatus, true);
+        assertFalse(updateFirstCommand.equals(updateFirstCommandForce));
+
+        // different status -> returns false
+        Status differentStatus = new Status("Rejected");
+        UpdateCommand updateFirstCommandDifferentStatus = new UpdateCommand(INDEX_FIRST_PERSON, differentStatus, false);
+        assertFalse(updateFirstCommand.equals(updateFirstCommandDifferentStatus));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        Status status = new Status("Interview Scheduled");
+        UpdateCommand updateCommand = new UpdateCommand(targetIndex, status, false);
+        String expected = UpdateCommand.class.getCanonicalName()
+                + "{targetIndex=" + targetIndex
+                + ", status=" + status
+                + ", isForceOperation=false}";
+        assertEquals(expected, updateCommand.toString());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no one.
+     */
+    private void showNoPerson(Model model) {
+        model.updateFilteredPersonList(p -> false);
+        assertTrue(model.getFilteredPersonList().isEmpty());
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -52,7 +53,8 @@ public class AddressBookParserTest {
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " n/" + "Joe");
-        assertEquals(new DeleteCommand(new NameMatchesKeywordPredicate("Joe"), false), command);
+        assertEquals(new DeleteCommand((List<IdentifierPredicate>) new NameMatchesKeywordPredicate("Joe"),
+                false), command);
     }
 
     @Test


### PR DESCRIPTION
Solves #154 #158 #157 #164 #165

Expected behavior after this modification:
1. delete and update: Use **ONLY id or any combination of other identifiers** and all the identifiers include: id, name, phone, email, status, job_pos, before date, after date (for the update command, status must be included)
Any combination here means: find out the applicant(s) satisfying all the constraints

2. search: Use any combination of the identifiers
identifiers: all in 1. except id as id does not make sense here (name, phone, email, status, job_pos, before date, after date)
Any combination here means: find out the applicant(s) satisfying any one (instead of all) the constraints as suggested by #157 on Github

3. summary: similar to search
the difference is: that any combination means **all of** the constraints

NB:
1. The search command does not allow duplicate identifiers like "n/amy n/bob"
2. The test cases have not been fully added
3. One abstract class was created for the delete command and the update command to inherit. I did this because initially there was a lot of duplicate code between the delete command and the update command.