### PR TITLE
Block interactions with the main app window until the file chooser dialog is closed

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -48,7 +48,7 @@ public class MainWindow extends UiPart<Stage> {
     private StackPane resultDisplayPlaceholder;
 
     @FXML
-    private StackPane statusbarPlaceholder;
+    private StackPane statusBarPlaceholder;
 
     /**
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
@@ -117,7 +117,7 @@ public class MainWindow extends UiPart<Stage> {
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
-        statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
+        statusBarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
         CommandBox commandBox = new CommandBox(this::executeCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -44,7 +44,6 @@ public class PersonCard extends UiPart<Region> {
      */
     private static final long MAX_FILE_SIZE = 2 * 1024 * 1024; // 2 MB
     private static final String MAX_FILE_SIZE_STRING = "2MB";
-    private static Stage stage = new Stage();
     private MainWindow mainWindow;
     private Applicant applicant;
     private final Logger logger = LogsCenter.getLogger(PersonCard.class);

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -29,7 +29,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.applicant.Applicant;
 
 /**
- * An UI component that displays information of a {@code Applicant}.
+ * A UI component that displays information of a {@code Applicant}.
  */
 public class PersonCard extends UiPart<Region> {
 
@@ -42,9 +42,9 @@ public class PersonCard extends UiPart<Region> {
      *
      * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
      */
-    private static boolean isProfilePicClicked = false; // allow only one window pop up in a given moment
     private static final long MAX_FILE_SIZE = 2 * 1024 * 1024; // 2 MB
     private static final String MAX_FILE_SIZE_STRING = "2MB";
+    private static Stage stage = new Stage();
     private MainWindow mainWindow;
     private Applicant applicant;
     private final Logger logger = LogsCenter.getLogger(PersonCard.class);
@@ -188,14 +188,8 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private void handleImageClick() {
 
-        // prevent multiple window pop up
-        if (isProfilePicClicked) {
-            return;
-        }
-
         File selectedFile = this.chooseProfilePicture();
 
-        // if user didn't select a file OR selected file is too big
         if (selectedFile == null) {
             return;
         }
@@ -254,10 +248,8 @@ public class PersonCard extends UiPart<Region> {
                 new FileChooser.ExtensionFilter("Image Files",
                         "*.png", "*.jpg", "*.jpeg", "*.gif", ".tiff", "*.bmp", "*.webp"));
 
-        isProfilePicClicked = true;
         // open file chooser and return the selected file
-        File selectedFile = fileChooser.showOpenDialog(new Stage());
-        isProfilePicClicked = false;
+        File selectedFile = fileChooser.showOpenDialog(mainWindow.getPrimaryStage());
 
         if (selectedFile == null) {
             logger.info("User didn't select an image file");
@@ -266,7 +258,7 @@ public class PersonCard extends UiPart<Region> {
         }
 
         // check if the chosen file is too big
-        if (selectedFile != null && selectedFile.length() > MAX_FILE_SIZE) {
+        if (selectedFile.length() > MAX_FILE_SIZE) {
             logger.info("The selected image file exceeds " + MAX_FILE_SIZE_STRING);
             mainWindow.displayOversizeImageError(MAX_FILE_SIZE_STRING);
             return null;

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -52,7 +52,7 @@
           <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
         </VBox>
 
-        <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
+        <StackPane fx:id="statusBarPlaceholder" VBox.vgrow="NEVER" />
       </VBox>
     </Scene>
   </scene>


### PR DESCRIPTION
I use MainWindow's primary stage for `fileChooser.showOpenDialog(stage)` so the user can't interact with the main window until the pop up is closed.

fix #208 