### PR TITLE
Add invalid file format for export

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -15,6 +15,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_NO_RESULT = "No applicants found.";
     public static final String MESSAGE_UNKNOWN_FLAG = "Unknown flag: %1$s";
+    public static final String MESSAGE_INVALID_EXPORT_FORMAT = "File name must end with .csv";
     public static final String MESSAGE_INVALID_CHARACTER_FILENAME_FORMAT =
                 "Invalid filename. Only letters, digits, '-', '_', '.', and spaces are allowed.";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT =

--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -26,7 +26,7 @@ public class ExportCommandParser implements Parser<ExportCommand> {
             throw new ParseException(MESSAGE_INVALID_CHARACTER_FILENAME_FORMAT);
         }
 
-        // Append .csv if not already there
+        // Check if file is a csv
         if (!trimmed.endsWith(".csv")) {
             throw new ParseException(MESSAGE_INVALID_EXPORT_FORMAT);
         }

--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_CHARACTER_FILENAME_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_EMPTY_FILENAME_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_EXPORT_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_LONG_FILENAME_FORMAT;
 
 import seedu.address.logic.commands.ExportCommand;
@@ -27,7 +28,7 @@ public class ExportCommandParser implements Parser<ExportCommand> {
 
         // Append .csv if not already there
         if (!trimmed.endsWith(".csv")) {
-            trimmed += ".csv";
+            throw new ParseException(MESSAGE_INVALID_EXPORT_FORMAT);
         }
 
         // Avoid file name too long


### PR DESCRIPTION
Fixes #209 

Added a new exception for export command : non-csv file name

Old behavior : just append .csv if file isnt in .csv
New behavior : throw exception if not in .csv